### PR TITLE
fix locutus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,12 @@ COPY . operator/
 COPY ./jsonnet/vendor/github.com/observatorium/deployments/components/ components/
 COPY ./jsonnet/vendor/github.com/observatorium/deployments/environments/base/default-config.libsonnet operator/jsonnet/
 # Build
+WORKDIR /workspace/operator
 RUN GO111MODULE="on" go build github.com/brancz/locutus
 
 FROM alpine:3.10 as runner
 WORKDIR /
-COPY --from=builder /workspace/locutus /
+COPY --from=builder /workspace/operator/locutus /
 COPY --from=builder /workspace/operator/jsonnet /environments/operator
 COPY --from=builder /workspace/components/ /components/
 COPY --from=builder /workspace/operator/jsonnet/vendor/ /vendor/


### PR DESCRIPTION
We cannot use the latest locutus due to https://github.com/brancz/locutus/issues/44
use the previous stable version of locutus and fix the dockerfile to use the specified locutus in go.mod rather than latest one.