### PR TITLE
Export connectionLimit and maxItemSize for memcached

### DIFF
--- a/api/v1alpha1/observatorium_types.go
+++ b/api/v1alpha1/observatorium_types.go
@@ -164,6 +164,10 @@ type MemCacheSpec struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 	// Memory limit of Memcached in megabytes.
 	MemoryLimitMB *int32 `json:"memoryLimitMb,omitempty"`
+	// Max item size (default: 1m, min: 1k, max: 1024m)
+	MaxItemSize string `json:"maxItemSize,omitempty"`
+	// Max simultaneous connections
+	ConnectionLimit *int32 `json:"connectionLimit,omitempty"`
 	// Compute Resources required by this container.
 	// +optional
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -202,6 +202,11 @@ func (in *MemCacheSpec) DeepCopyInto(out *MemCacheSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ConnectionLimit != nil {
+		in, out := &in.ConnectionLimit, &out.ConnectionLimit
+		*out = new(int32)
+		**out = **in
+	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	in.ExporterResources.DeepCopyInto(&out.ExporterResources)
 }

--- a/manifests/crds/core.observatorium.io_observatoria.yaml
+++ b/manifests/crds/core.observatorium.io_observatoria.yaml
@@ -1007,6 +1007,10 @@ spec:
                       cache:
                         description: Memcached spec for QueryFrontend
                         properties:
+                          connectionLimit:
+                            description: Max simultaneous connections
+                            format: int32
+                            type: integer
                           exporterImage:
                             description: Memcached Prometheus Exporter image
                             type: string
@@ -1037,6 +1041,9 @@ spec:
                             type: string
                           image:
                             description: Memcached image
+                            type: string
+                          maxItemSize:
+                            description: 'Max item size (default: 1m, min: 1k, max: 1024m)'
                             type: string
                           memoryLimitMb:
                             description: Memory limit of Memcached in megabytes.
@@ -1458,6 +1465,10 @@ spec:
                       cache:
                         description: Memcached spec for Store
                         properties:
+                          connectionLimit:
+                            description: Max simultaneous connections
+                            format: int32
+                            type: integer
                           exporterImage:
                             description: Memcached Prometheus Exporter image
                             type: string
@@ -1488,6 +1499,9 @@ spec:
                             type: string
                           image:
                             description: Memcached image
+                            type: string
+                          maxItemSize:
+                            description: 'Max item size (default: 1m, min: 1k, max: 1024m)'
                             type: string
                           memoryLimitMb:
                             description: Memory limit of Memcached in megabytes.


### PR DESCRIPTION
export connectionLimit and maxItemSize for memcached so that we can make changes for tons of metrics case.
https://github.com/open-cluster-management/backlog/issues/11909

Signed-off-by: clyang82 <chuyang@redhat.com>