### PR TITLE
make thanos field optional for backcompatibility.

### DIFF
--- a/api/v1alpha1/observatorium_types.go
+++ b/api/v1alpha1/observatorium_types.go
@@ -29,6 +29,7 @@ type ObservatoriumSpec struct {
 	// Hashrings describes a list of Hashrings
 	Hashrings []*Hashring `json:"hashrings"`
 	// Thanos Spec
+        // +optional
 	Thanos ThanosSpec `json:"thanos"`
 	// API
 	API APISpec `json:"api,omitempty"`

--- a/api/v1alpha1/observatorium_types.go
+++ b/api/v1alpha1/observatorium_types.go
@@ -29,7 +29,7 @@ type ObservatoriumSpec struct {
 	// Hashrings describes a list of Hashrings
 	Hashrings []*Hashring `json:"hashrings"`
 	// Thanos Spec
-        // +optional
+	// +optional
 	Thanos ThanosSpec `json:"thanos"`
 	// API
 	API APISpec `json:"api,omitempty"`

--- a/manifests/crds/core.observatorium.io_observatoria.yaml
+++ b/manifests/crds/core.observatorium.io_observatoria.yaml
@@ -1737,7 +1737,6 @@ spec:
             required:
             - hashrings
             - objectStorageConfig
-            - thanos
             type: object
           status:
             description: ObservatoriumStatus defines the observed state of Observatorium


### PR DESCRIPTION
ref: https://github.com/open-cluster-management/backlog/issues/12807

Signed-off-by: morvencao <lcao@redhat.com>