### PR TITLE
ceil for ignoreDeletionMarksDelay when deleteDelay is odd number

### DIFF
--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -36,7 +36,7 @@ local operatorObs = obs {
     stores+:: {
       local deleteDelay = if std.objectHas(cr.spec.thanos, 'compact') && std.objectHas(cr.spec.thanos.compact, 'deleteDelay') then cr.spec.thanos.compact.deleteDelay else obs.thanos.compact.config.deleteDelay,
       securityContext: if std.objectHas(cr.spec, 'securityContext') then cr.spec.securityContext else obs.thanos.stores.config.securityContext,
-      ignoreDeletionMarksDelay: std.parseInt(std.substr(deleteDelay, 0, std.length(deleteDelay) - 1)) / 2 + std.substr(deleteDelay, std.length(deleteDelay) - 1, std.length(deleteDelay)),
+      ignoreDeletionMarksDelay: std.ceil(std.parseInt(std.substr(deleteDelay, 0, std.length(deleteDelay) - 1)) / 2) + std.substr(deleteDelay, std.length(deleteDelay) - 1, std.length(deleteDelay)),
     } + if std.objectHas(cr.spec.thanos, 'store') then cr.spec.thanos.store else {},
 
     storeCache+:: (if std.objectHas(cr.spec.thanos, 'store') && std.objectHas(cr.spec.thanos.store, 'cache') then cr.spec.thanos.store.cache else {}) + {


### PR DESCRIPTION
when `deleteDelay` is odd number, we need to ceil for `ignoreDeletionMarksDelay`, for example：

if deleteDelay is 3h, then ignoreDeletionMarksDelay should be 2h.

https://github.com/open-cluster-management/backlog/issues/12690

Signed-off-by: Song Song Li <ssli@redhat.com>